### PR TITLE
Fix black-check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -126,6 +126,8 @@ deps =
     -cconstraints.txt
     # BBB: black 21.12b0 it is the last version with python2 support.
     black[python2]==21.12b0
+    # BBB: click > 8.0.4 causes error on black < 22.3.0.
+    click==8.0.4
 
 commands =
     black --check --diff -v src setup.py


### PR DESCRIPTION
`click` > 8.0.4 causes error on `black` < 22.3.0:

```
ImportError: cannot import name '_unicodefun' from 'click'
```

See:

psf/black#2964

We can't update the version of black now because `black` 21.12b0 it is the last version with python2 support.