### PR TITLE
Fix AttributeError when trying to create a Plone Site on an instance that has collective.js.galleria available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``AttributeError`` when trying to create a Plone Site on an instance that has
+  ``collective.js.galleria`` available.
+  [wesleybl]
 
 
 1.6.2 (2022-05-20)

--- a/src/collective/js/galleria/setuphandlers.py
+++ b/src/collective/js/galleria/setuphandlers.py
@@ -9,6 +9,10 @@ class HiddenProfiles(object):
         """Hide the upgrades package from prefs_install_products_form."""
         return ["collective.js.galleria.upgrades"]
 
+    def getNonInstallableProfiles(self):
+        """Hide profiles from site-creation and quickinstaller."""
+        return ["collective.js.galleria:uninstall"]
+
 
 def post_install(context):
     """Post install script"""

--- a/src/collective/js/galleria/tests/__init__.py
+++ b/src/collective/js/galleria/tests/__init__.py
@@ -8,3 +8,7 @@ class HiddenProfiles(object):
     def getNonInstallableProducts(self):
         """Hide tests profiles from prefs_install_products_form."""
         return ["collective.js.galleria.tests"]
+
+    def getNonInstallableProfiles(self):
+        """Hide profiles from site-creation and quickinstaller."""
+        return []

--- a/src/collective/js/galleria/tests/test_setup.py
+++ b/src/collective/js/galleria/tests/test_setup.py
@@ -3,6 +3,7 @@ from collective.js.galleria.testing import INTEGRATION_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.browser.admin import AddPloneSite
 from Products.CMFPlone.controlpanel.browser.quickinstaller import ManageProductsView
 from Products.CMFPlone.interfaces import IBundleRegistry
 from Products.CMFPlone.utils import get_installer
@@ -49,6 +50,20 @@ class InstallTestCase(unittest.TestCase):
             if profile["id"].startswith("collective.js.galleria")
         ]
         self.assertEqual([], package_profiles_availables)
+
+    def test_hide_extensions_profiles(self):
+        app = self.layer["app"]
+        request = self.layer["request"]
+        add_plone_site = AddPloneSite(app, request)
+        profiles = add_plone_site.profiles()
+        extensions_profiles = profiles["extensions"]
+        profiles_ids = [profile["id"] for profile in extensions_profiles]
+        package_profiles = [
+            profile_id
+            for profile_id in profiles_ids
+            if profile_id.startswith(PROJECTNAME)
+        ]
+        self.assertEqual(["collective.js.galleria:default"], package_profiles)
 
 
 class UninstallTestCase(unittest.TestCase):


### PR DESCRIPTION
Objects that implement the `INonInstallable` interface must have the `getNonInstallableProfiles` method. Without it we get the error:

```
AttributeError: 'HiddenProfiles' object has no attribute 'getNonInstallableProfiles'
```
when trying to create a Plone Site.