### PR TITLE
Fix invalid specifier error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix invalid specifier erro in python_requires.
+  [mauvictor]
 
 
 1.6.3 (2022-05-26)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*!=3.5.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     install_requires=[
         "setuptools",
         "plone.app.registry",


### PR DESCRIPTION
Added a fix to error:   " error in collective.js.galleria setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '!=3.4.*!=3.5.*' "